### PR TITLE
Change Log: Login/Account Creation logic fix

### DIFF
--- a/src/InCollege.cob
+++ b/src/InCollege.cob
@@ -245,9 +245,7 @@ MAIN-MENU-DISPLAY.
        PERFORM WRITE-AND-DISPLAY.
        MOVE "Create New Account" TO OUTPUT-LINE.
        PERFORM WRITE-AND-DISPLAY.
-       MOVE "Please enter your username:" TO OUTPUT-LINE.
-       PERFORM WRITE-AND-DISPLAY.
-       MOVE "Please enter your password:" TO OUTPUT-LINE.
+       MOVE "Enter your selection:" TO OUTPUT-LINE.
        PERFORM WRITE-AND-DISPLAY.
 
 PROCESS-INPUT-COMMANDS.
@@ -260,12 +258,12 @@ PROCESS-INPUT-COMMANDS.
 
                *> switch case
                EVALUATE USER-ACTION
-                   WHEN "new account"
+                   WHEN "Create New Account"
                        PERFORM CREATE-ACCOUNT-SECTION
-                   WHEN "login"
+                   WHEN "Log In"
                        PERFORM LOGIN-SECTION
                    WHEN OTHER
-                       MOVE "Error: Input must be 'new account' or 'login'."
+                       MOVE "Error: Input must be 'Log In' or 'Create New Account'."
                            TO OUTPUT-LINE
                        PERFORM WRITE-AND-DISPLAY
                END-EVALUATE
@@ -273,6 +271,8 @@ PROCESS-INPUT-COMMANDS.
 
 GET-USERNAME.
        *> reads the next line from the input file and store it as the username
+       MOVE "Please enter your username:" TO OUTPUT-LINE.
+       PERFORM WRITE-AND-DISPLAY.
        READ INPUT-FILE
            AT END
                SET EOF TO TRUE
@@ -282,6 +282,8 @@ GET-USERNAME.
 
 GET-PASSWORD.
        *> reads the next line from the input file and store it as the password
+       MOVE "Please enter your password:" TO OUTPUT-LINE.
+       PERFORM WRITE-AND-DISPLAY.
        READ INPUT-FILE
            AT END
                SET EOF TO TRUE


### PR DESCRIPTION
Fixed login order logic in the program:
- It now displays "Enter your selection" before prompting for username and password.
- Based on the user selecting "Log In" or "Create New Account", it will prompt for the username and password.

Changes Made:
1. Fixed premature prompts in MAIN-MENU-DISPLAY: -Removed early "Please enter your username:" and "Please enter your password:" prompts -Added missing "Enter your selection:" prompt
2. Updated input validation in PROCESS-INPUT-COMMANDS: -Changed expected inputs from "login"/"new account" to "Log In"/"Create New Account" -Updated error message to reflect correct input format
3. Added missing prompts to input functions: -GET-USERNAME: Added "Please enter your username:" prompt before reading input -GET-PASSWORD: Added "Please enter your password:" prompt before reading input

Result: Login flow now correctly displays menu → waits for selection → prompts for credentials in sequence.